### PR TITLE
feat: support multiple plugin instances in one build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ const defaultOptions: Options = {
 }
 
 export default createUnplugin<Partial<Options>>((userOptions = {}) => {
-  const options: Options = Object.assign(defaultOptions, userOptions)
+  const options: Options = Object.assign({}, defaultOptions, userOptions)
   const filter = createFilter(options.include, options.exclude)
 
   return {


### PR DESCRIPTION
Do not override defaultOptions, copy from it instead.

```js
// https://vitejs.dev/config/
export default defineConfig({
  plugins: [
    vue(),
    ElementPlus({ lib: "@scope/element-plus", }),
    ElementPlus({ lib: "element-plus", })
  ],
});
```